### PR TITLE
fix: brick reference

### DIFF
--- a/mason.yaml
+++ b/mason.yaml
@@ -8,7 +8,7 @@ bricks:
   # Uncomment the following lines to import
   # a brick from a remote git url.
   bloc_feature:
-    path: bloc_feature
+    path: bricks/bloc_feature
   
   # widget:
   #   git:


### PR DESCRIPTION
Added the brick reference inside the **mason.yaml** making the `mason get` command work